### PR TITLE
Polishing popup interface 

### DIFF
--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -5,7 +5,7 @@ html body {
 .panel {
   display: flex;
   flex-direction: column;
-  width: 20em;
+  min-width: 20em;
   height: 30em;
   background-color: #ffffff;
 }
@@ -55,6 +55,8 @@ p {
 .panel-section-footer {
   height: auto;
   min-height: 41px;
+  border-radius: 0;
+  border: 0;
 }
 
 .footer-button-icon {
@@ -63,6 +65,10 @@ p {
   mask-size: 32px;
   mask-position: center center;
   mask-repeat: no-repeat;
+}
+
+#show-all-button {
+  box-shadow: none;
 }
 
 #new-button > .footer-button-icon {
@@ -111,4 +117,10 @@ p {
 
 .menu-content li:hover {
   background-color: rgba(12, 12, 13, 0.1);
+}
+
+@media (max-width: 425px) {
+  .panel {
+    width: auto !important;
+  }
 }

--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -6,7 +6,8 @@ html body {
   display: flex;
   flex-direction: column;
   min-width: 20em;
-  height: 30em;
+  min-height: 30em;
+  height: 100vh;
   background-color: #ffffff;
 }
 


### PR DESCRIPTION
Hello @sneakypete81 

This PR remove rounded corners and borders that, in my opinion weren't looking very good, and expand the interface when the popup button is placed in the [Extra Menu](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Popups#Popup_resizing)

|-|Before|After|
|--|--|--|
|Browser action bar|<img width="300" alt="before2" src="https://user-images.githubusercontent.com/6209647/52127656-01fc2480-2633-11e9-86d3-cff97d8151cc.png">|<img width="299" alt="after2" src="https://user-images.githubusercontent.com/6209647/52127654-01638e00-2633-11e9-8833-c4c56d8c791c.png">|
|Extra Menu|<img width="418" alt="before1" src="https://user-images.githubusercontent.com/6209647/52127655-01638e00-2633-11e9-8089-1b0a219bd2e3.png">|<img width="420" alt="after1" src="https://user-images.githubusercontent.com/6209647/52127651-01638e00-2633-11e9-97dc-d9f4459bc030.png">|
