### PR TITLE
Implement user definable pause between scans

### DIFF
--- a/src/app/popup/popup.html
+++ b/src/app/popup/popup.html
@@ -28,6 +28,7 @@
           <li id="scan-all-menu">Scan All Pages</li>
           <li id="backup-menu">Backup Pages</li>
           <li id="restore-menu">Restore Pages</li>
+          <li id="interval-menu">Set Scan Interval</li>
           <li id="help-menu">Help</li>
         </ul>
       </div>
@@ -99,6 +100,32 @@
     <div class="panel-section panel-section-footer">
       <div id="restore-button" class="panel-section-footer-button default">
         Restore Pages
+      </div>
+    </div>
+  </div>
+  
+  <!-- -->
+  
+  <div id="interval-panel" class="panel hidden">
+    <div class="panel-section panel-section-header">
+      <div class="text-section-header">Set Scan Interval</div>
+    </div>
+
+    <div class="panel-section panel-section-content">
+      <p>
+        Here you can set the time Update Scanner will wait in seconds before scanning the next page in the scan queue. <br>
+        The default time is 2 seconds. <br>
+        Any time lower than this will silently be increased to 2 seconds.
+      </p>
+      <br>
+      <div style="text-align:center">
+      <input id="interval-value" type="number" name="interval-value" value="2">
+      </div>
+    </div>
+
+    <div class="panel-section panel-section-footer">
+      <div id="interval-button" class="panel-section-footer-button default">
+        Set Interval
       </div>
     </div>
   </div>

--- a/src/lib/background/background.js
+++ b/src/lib/background/background.js
@@ -8,6 +8,7 @@ import {isUpToDate, latestVersion} from '/lib/update/update.js';
 import {openUpdate} from '/lib/update/update_url.js';
 import {log} from '/lib/util/log.js';
 import {Config} from '/lib/util/config.js';
+import {saveScanFirstRun} from '/lib/util/interval.js';
 
 const activeIcon = {
   18: '/images/updatescanner_18.png',
@@ -93,6 +94,7 @@ export class Background {
   /**
    * If this is the first time the addon has been run, create a Page with
    * the Update Scanner website and scan it immediately.
+   * Then, set the scan interval to it's default (2 seconds).
    */
   async _checkFirstRun() {
     const config = await new Config().load();
@@ -101,6 +103,7 @@ export class Background {
       config.set('isFirstRun', false);
       config.set('updateVersion', latestVersion);
       await config.save();
+      saveScanFirstRun();
 
       this.scanQueue.add([page]);
       this.scanQueue.scan();

--- a/src/lib/popup/popup.js
+++ b/src/lib/popup/popup.js
@@ -7,6 +7,8 @@ import {PageStore, hasPageStateChanged, isItemChanged}
 import {createBackupJson} from '/lib/backup/backup.js';
 import {openRestoreUrl} from '/lib/backup/restore_url.js';
 import {waitForMs} from '/lib/util/promise.js';
+import {saveScanInterval} from '/lib/util/interval.js';
+import {qs} from '/lib/util/view_helpers.js';
 
 /**
  * Class representing the Update Scanner toolbar popup.
@@ -37,6 +39,7 @@ export class Popup {
     view.bindScanAllClick(this._handleScanAllClick.bind(this));
     view.bindBackupClick(this._handleBackupClick.bind(this));
     view.bindRestoreClick(this._handleRestoreClick.bind(this));
+    view.bindIntervalClick(this._handleIntervalClick.bind(this));
     view.bindHelpClick(this._handleHelpClick.bind(this));
     view.bindPageClick(this._handlePageClick.bind(this));
 
@@ -107,6 +110,19 @@ export class Popup {
    */
   async _handleRestoreClick() {
     openRestoreUrl();
+  }
+
+  /**
+   * Called when the Interval menu item is clicked, to set the scan interval.
+   * Gets the interval value from the form in the interval-panel.
+   */
+  async _handleIntervalClick() {
+    const passthis = qs('#interval-value').value;
+    try {
+      saveScanInterval(passthis);
+    } catch (error) {
+      console.log(`ERROR: Popup.handleintervalclick: ${error}`);
+    }
   }
 
   /**

--- a/src/lib/popup/popup_view.js
+++ b/src/lib/popup/popup_view.js
@@ -9,6 +9,7 @@ export function init() {
   $on(qs('#menu-button'), 'click', toggleMenu);
   $on(qs('#backup-menu'), 'click', showBackupPanel);
   $on(qs('#restore-menu'), 'click', showRestorePanel);
+  $on(qs('#interval-menu'), 'click', showIntervalPanel);
 }
 
 /**
@@ -58,6 +59,13 @@ export function bindRestoreClick(handler) {
  */
 export function bindScanAllClick(handler) {
   $on(qs('#scan-all-menu'), 'click', handler);
+}
+
+/**
+ * @param {Function} handler - Called when the Interval menu item is clicked.
+ */
+export function bindIntervalClick(handler) {
+  $on(qs('#interval-button'), 'click', handler);
 }
 
 /**
@@ -163,4 +171,12 @@ function showBackupPanel() {
 function showRestorePanel() {
   hideElement(qs('#main-panel'));
   showElement(qs('#restore-panel'));
+}
+
+/**
+ * Display the Set Interval panel.
+ */
+function showIntervalPanel() {
+  hideElement(qs('#main-panel'));
+  showElement(qs('#interval-panel'));
 }

--- a/src/lib/scan/scan.js
+++ b/src/lib/scan/scan.js
@@ -5,6 +5,7 @@ import {isUpToDate} from '/lib/update/update.js';
 import {log} from '/lib/util/log.js';
 import {waitForMs} from '/lib/util/promise.js';
 import {detectEncoding, applyEncoding} from '/lib/util/encoding.js';
+import {loadScanInterval} from '/lib/util/interval.js';
 
 /**
  * Enumeration indicating the similarity of two HTML strings.
@@ -36,7 +37,7 @@ export const __ = {
 };
 
 // Wait between scanning pages
-const SCAN_IDLE_MS = 2000;
+let SCAN_IDLE_MS = 2000;
 
 /**
  * Start scanning the pages one at a time. HTML is checked for updates and
@@ -48,6 +49,8 @@ const SCAN_IDLE_MS = 2000;
  */
 export async function scan(pageList) {
   let newMajorChangeCount = 0;
+  SCAN_IDLE_MS = await loadScanInterval();
+
   for (const page of pageList) {
     if (await scanPage(page)) {
       newMajorChangeCount++;

--- a/src/lib/scan/scan_queue.js
+++ b/src/lib/scan/scan_queue.js
@@ -1,5 +1,6 @@
 import {scanPage} from './scan.js';
 import {waitForMs} from '/lib/util/promise.js';
+import {loadScanInterval} from '/lib/util/interval.js';
 
 // Allow function mocking
 export const __ = {
@@ -8,7 +9,7 @@ export const __ = {
 };
 
 // Wait between scanning pages
-const SCAN_IDLE_MS = 2000;
+let SCAN_IDLE_MS = 2000;
 
 /**
  * @typedef {Object} ScanResult
@@ -97,6 +98,7 @@ export class ScanQueue {
   async _processScanQueue() {
     let majorChanges = 0;
     let scanCount = 0;
+    SCAN_IDLE_MS = await loadScanInterval();
 
     while (this.queue.length > 0) {
       const majorChange = await __.scanPage(this.queue.shift());

--- a/src/lib/util/interval.js
+++ b/src/lib/util/interval.js
@@ -1,0 +1,57 @@
+import {waitForMs} from '/lib/util/promise.js';
+import {log} from '/lib/util/log.js';
+
+/**
+ * Sets default scan interval on first run (2000 milliseconds).
+ */
+export async function saveScanFirstRun() {
+  try {
+    await browser.storage.local.set({'gimmeinterval': 2000});
+    // Short delay to avoid that error or something that pops up in the console.
+    await waitForMs(100);
+  } catch (error) {
+    console.log(`ERROR: Interval.save: ${error}`);
+  }
+}
+
+/**
+ * Saves the scan interval.
+ *
+ * @param {int} passthis - The time to wait between scans in seconds.
+ */
+ export async function saveScanInterval(passthis) {
+    // Convert to milliseconds.
+    const tempInterval = 1000*parseInt(passthis, 10);
+
+    // If given time is lower than 2 seconds, set to 2 seconds.
+    try {
+      if (tempInterval >= 2000) {
+        await browser.storage.local.set({'gimmeinterval': tempInterval});
+      } else {
+      await browser.storage.local.set({'gimmeinterval': 2000});
+      }
+      // Short delay to avoid that one error or something.
+      await waitForMs(100);
+      window.close();
+    } catch (error) {
+      console.log(`ERROR: Interval.save: ${error}`);
+    }
+}
+
+/**
+ * Gets the scan interval.
+ *
+ * @returns {int} The time to wait between scans in milliseconds.
+ */
+ export async function loadScanInterval() {
+    try {
+      const interval = await browser.storage.local.get('gimmeinterval');
+      log('Time to wait in ms between scans: '+interval.gimmeinterval);
+      // Short delay to avoid that one error or something.
+      await waitForMs(100);
+      return (parseInt(interval.gimmeinterval));
+
+    } catch (error) {
+      console.log(`ERROR: Interval.load: ${error}`);
+    }
+ }


### PR DESCRIPTION
This adds the first feature mentioned in https://github.com/sneakypete81/updatescanner/issues/1.
It adds a menu entry in the popup that lets you set the time to wait before scanning the next page: 
![pull req1](https://user-images.githubusercontent.com/47357135/52511173-e366d200-2bcc-11e9-9873-55cff344f226.png) ![pull req2](https://user-images.githubusercontent.com/47357135/52511678-13af7000-2bcf-11e9-89b2-0eecf09c1067.png)


Also adds that time to the console output:
![pull req3](https://user-images.githubusercontent.com/47357135/52511196-f083c100-2bcc-11e9-9e94-9374da56bbfa.PNG)


