### PR TITLE
Fix footer buttons cutting when there are a lot of elements.

### DIFF
--- a/src/app/popup/popup.css
+++ b/src/app/popup/popup.css
@@ -60,6 +60,10 @@ p {
   border: 0;
 }
 
+.panel-section-footer:last-child {
+  min-height: 76px;
+}
+
 .footer-button-icon {
   background-color: rgba(12, 12, 13, 0.8);
   height: 32px;


### PR DESCRIPTION
Quoting from #322 :

> BTW, do you have any ideas on how to fix the remaining issue in #178? The buttons get truncated when there are lots of items displayed in the popup:

In the very spirit as https://github.com/sneakypete81/updatescanner/blob/89ec21fdf8ffee26d516048b5f295c4e642590c7/src/app/popup/popup.css#L58 where you hard coded 41px of height, I found that explicitly setting the minimum height for the buttons should fix the issue:

|Browser Bar| Overflow Menu |
|--|--|
|<img width="295" alt="schermata 2019-02-13 alle 22 28 42" src="https://user-images.githubusercontent.com/6209647/52745907-90cc5200-2fe0-11e9-987f-2086a5005e92.png">|<img width="399" alt="schermata 2019-02-13 alle 22 38 22" src="https://user-images.githubusercontent.com/6209647/52745909-9164e880-2fe0-11e9-9bd4-68fb41668182.png">|

The screenshots were took on Firefox 65.0 and MacOS Mojave 10.14.3 (18D42) with Retina Screen.