### PR TITLE
Use node LTS for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: lts/*
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
Prevents node-gyp compilation issue present in node v12.3.0