### PR TITLE
add explicit content_security_policy

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,6 +15,7 @@
     "48": "images/updatescanner_48.png",
     "96": "images/updatescanner_96.png"
   },
+  "content_security_policy": "default-src 'none'; script-src 'self'; object-src 'self'; connect-src 'none'; base-uri 'none';",
   "permissions": [
     "<all_urls>",
     "alarms",


### PR DESCRIPTION
This should reduce security risk score as evaluated on
https://crxcavator.io/report/%7Bc07d1a49-9894-49ff-a594-38960ede8fb9%7D?platform=Firefox&new_scan=true

No XHR identified for connect-src